### PR TITLE
Rename "Size" to "Content-Length" and fix conversion

### DIFF
--- a/pkg/core/handlers.go
+++ b/pkg/core/handlers.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"net/http"
 	"time"
+	"strconv"
 )
 
 // ResourceInfo describes the metadata of the resource.
@@ -58,7 +59,7 @@ func SetDefaultHeaders(w http.ResponseWriter, info ResourceInfo) {
 	w.Header().Set("Content-Type", info.ContentType)
 	w.Header().Set("ETag", info.ETag)
 	w.Header().Set("Last-Modified", info.LastModified.Format(time.RFC1123))
-	w.Header().Set("Size", string(info.Size))
+	w.Header().Set("Content-Length", strconv.FormatInt(info.Size, 10))
 }
 
 // DefaultServe serve the Resource.


### PR DESCRIPTION
The correct http header is "Content-Length", not "Size". Also the value is broken:
```
-> % http -h http://localhost:8080/foo.zip
HTTP/1.1 200 OK
Content-Type: application/zip
Date: Tue, 20 Apr 2021 07:25:06 GMT
Etag: 15725abda7f60f3f004c09b6aafda95e
Last-Modified: Fri, 16 Apr 2021 14:40:18 UTC
Size: ï¿½
Transfer-Encoding: chunked
```

This PR fixes this:
```
-> % http -h http://localhost:8080/foo.zip
HTTP/1.1 200 OK
Content-Length: 287682419
Content-Type: application/zip
Date: Tue, 20 Apr 2021 07:32:13 GMT
Etag: 15725abda7f60f3f004c09b6aafda95e
Last-Modified: Fri, 16 Apr 2021 14:40:18 UTC
```